### PR TITLE
Add Readme info install not packagist

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,6 +26,19 @@ or
 php composer.phar require yandex/webmaster.api "dev-master"
 ```
 
+
+Also required prior to placing the package on packagist.org
+```js
+    ...
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/yandex/webmaster.api"
+        }
+    ]
+    ...
+```
+
 ### Manual
 
 Clone repository and require webmasterApi.php

--- a/webmaster_api.class.php
+++ b/webmaster_api.class.php
@@ -4,6 +4,9 @@ require_once(realpath(dirname(__FILE__)) . '/src/webmasterApi.php');
 
 /**
  * @deprecated
+ * The library moved to the SRC folder, accessible through the installation composer
+ * We recommend to use a class through Yandex \ webmaster \ api \ webmasterApi
+ * 
  * Библиотека переехала в папку src , доступна установка через composer
  * Советуем использовать класс через yandex\webmaster\api\webmasterApi
  */


### PR DESCRIPTION
Добавил в Readmi пример подключения через композер.
Было бы хорошо разместить пакет на pakagist 
https://packagist.org/packages/yandex/